### PR TITLE
Adds Code Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,28 @@ jobs:
             echo "${JSON_FIREBASE_RELEASE}" >> "app/src/release/google-services.json"
 
       - run:
+          name: Run Linters
+          command: ./gradlew check
+
+      - run:
+          name: Run Tests and generate Code Coverage
+          command: ./gradlew createCombinedCoverageReport
+
+      - run:
+          name: Upload code coverage data
+          command: ./gradlew coveralls
+
+      - run:
           name: Build
-          command: ./gradlew clean check assemble assembleAndroidTest
+          command: ./gradlew assemble assembleAndroidTest
+
+      - store_artifacts:
+          path: app/build/reports/jacoco/createCombinedCoverageReport
+          destination: coverage-report
+
+      - store_artifacts:
+          path: app/build/reports/tests/testDebugUnitTest
+          destination: local-test-report
 
       - save_cache:
           paths:

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@ Social App
 ==========
 
 [![CircleCI](https://circleci.com/gh/rafaeltoledo/social-app.svg?style=svg)](https://circleci.com/gh/rafaeltoledo/social-app)
+[![Coverage Status](https://coveralls.io/repos/github/rafaeltoledo/social-app/badge.svg?branch=develop)](https://coveralls.io/github/rafaeltoledo/social-app?branch=develop)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
+apply from: "$rootDir/tools/coverage.gradle"
+
 android {
     compileSdkVersion 27
 
@@ -38,6 +40,8 @@ android {
 
     buildTypes {
         debug {
+            testCoverageEnabled true
+
             applicationIdSuffix '.dev'
             signingConfig signingConfigs.debug
         }
@@ -47,6 +51,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    testOptions {
+        unitTests.includeAndroidResources true
     }
 }
 
@@ -58,6 +66,7 @@ dependencies {
     implementation "com.google.firebase:firebase-core:$versions.googleServices"
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.8'
 
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/test/kotlin/net/rafaeltoledo/social/MainActivityTest.kt
+++ b/app/src/test/kotlin/net/rafaeltoledo/social/MainActivityTest.kt
@@ -1,0 +1,16 @@
+package net.rafaeltoledo.social
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MainActivityTest {
+
+    @Test
+    fun checkIfActivityIsSuccessfullyCreated() {
+        assertNotNull(Robolectric.setupActivity(MainActivity::class.java))
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,14 @@ buildscript {
     repositories {
         google()
         jcenter()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'com.google.gms:google-services:3.2.1'
         classpath "org.jacoco:org.jacoco.core:$versions.jacoco"
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ buildscript {
     ext.versions = [
             'kotlin': '1.2.31',
             'supportLibrary': '27.1.0',
-            'googleServices': '12.0.1'
+            'googleServices': '12.0.1',
+            'jacoco': '0.8.1'
     ]
     
     repositories {
@@ -14,6 +15,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'com.google.gms:google-services:3.2.1'
+        classpath "org.jacoco:org.jacoco.core:$versions.jacoco"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
 
     ext.versions = [
             'kotlin': '1.2.31',
-            'supportLibrary': '27.1.0',
+            'supportLibrary': '27.1.1',
             'googleServices': '12.0.1',
             'jacoco': '0.8.1'
     ]

--- a/tools/coverage.gradle
+++ b/tools/coverage.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "$versions.jacoco"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+task createCombinedCoverageReport(type: JacocoReport,
+        dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    def classes = fileTree(dir: "$buildDir/tmp/kotlin-classes/debug")
+
+    sourceDirectories = files("$projectDir/src/main/kotlin")
+    classDirectories = files(classes)
+    executionData = fileTree(dir: buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec',
+            'outputs/code-coverage/connected/*coverage.ec'
+    ])
+
+    reports {
+        xml.enabled = true
+        xml.destination file("$buildDir/reports/jacoco/report.xml")
+
+        html.enabled = true
+    }
+}

--- a/tools/coverage.gradle
+++ b/tools/coverage.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 jacoco {
     toolVersion = "$versions.jacoco"
@@ -8,12 +9,14 @@ tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
 }
 
+def classes = fileTree(dir: "$buildDir/tmp/kotlin-classes/debug")
+def sources = files("$projectDir/src/main/kotlin")
+def report = "$buildDir/reports/jacoco/report.xml"
+
 task createCombinedCoverageReport(type: JacocoReport,
         dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
 
-    def classes = fileTree(dir: "$buildDir/tmp/kotlin-classes/debug")
-
-    sourceDirectories = files("$projectDir/src/main/kotlin")
+    sourceDirectories = sources
     classDirectories = files(classes)
     executionData = fileTree(dir: buildDir, includes: [
             'jacoco/testDebugUnitTest.exec',
@@ -22,8 +25,13 @@ task createCombinedCoverageReport(type: JacocoReport,
 
     reports {
         xml.enabled = true
-        xml.destination file("$buildDir/reports/jacoco/report.xml")
+        xml.destination file(report)
 
         html.enabled = true
     }
+}
+
+coveralls {
+    sourceDirs = sources.flatten()
+    jacocoReportPath = report
 }


### PR DESCRIPTION
This PR adds the code coverage after successfully running tests. Sometime in a future, we'll need to think about how to run the instrumented tests on CI server to get a more precise metric - I played a bit using a headless emulator but didn't get success.

For registering coverage data, I'm using [Coveralls](https://coveralls.io/). I tried to use [Codecov](http://codecov.io), but it didn't work well with Kotlin yet. ~~Would be good to add a coverage metric when opening PRs, when possible~~.

This also updates Support Library to 27.1.1 and AGP to 3.1.1
