### PR TITLE
Moves Gradle custom scripts to gradle folder

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
-apply from: "$rootDir/tools/coverage.gradle"
+apply from: "$rootDir/gradle/coverage.gradle"
 
 android {
     compileSdkVersion 27

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
-jacoco {
-    toolVersion = "$versions.jacoco"
-}
+jacoco.toolVersion versions.jacoco
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true


### PR DESCRIPTION
As discussed internally with @victorolinasc, maybe the **gradle**
folder is a better place for our custom scripts. Also, simplifies the
Jacoco version block, as suggested.